### PR TITLE
Add App Engine Project ID to appengine-web.xml

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>YOUR_PROJECT_ID</application>
+    <application>codeu-team-1</application>
     <version>1</version>
     <threadsafe>false</threadsafe>
     <sessions-enabled>true</sessions-enabled>


### PR DESCRIPTION
I changed the <application> tag in appengine-web.xml to refer to the Project ID given by App Engine. This is one of the steps for the App Engine Setup. This lets us "deploy our server to the App Engine project we just created".