### PR TITLE
Finish Admin Page delete feature

### DIFF
--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -1,6 +1,9 @@
 package codeu.controller;
 
 import codeu.helper.AdminHelper;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.store.basic.UserStore;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -13,9 +16,52 @@ public class AdminServlet extends HttpServlet {
 
     private static final String ADMIN_MESSAGE = "adminMessage";
 
+    /** Store class that gives access to Conversations. */
+    private ConversationStore conversationStore;
+
+    /** Store class that gives access to Messages. */
+    private MessageStore messageStore;
+
+    /** Store class that gives access to Users. */
+    private UserStore userStore;
+
+    /** Set up state for admin page (displaying stats or allowing deletions) */
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        setConversationStore(ConversationStore.getInstance());
+        setMessageStore(MessageStore.getInstance());
+        setUserStore(UserStore.getInstance());
+    }
+
+    /**
+     * Sets the ConversationStore used by this servlet. This function provides a common setup method
+     * for use by the test framework or the servlet's init() function.
+     */
+    void setConversationStore(ConversationStore conversationStore) {
+        this.conversationStore = conversationStore;
+    }
+
+    /**
+     * Sets the MessageStore used by this servlet. This function provides a common setup method for
+     * use by the test framework or the servlet's init() function.
+     */
+    void setMessageStore(MessageStore messageStore) {
+        this.messageStore = messageStore;
+    }
+
+    /**
+     * Sets the UserStore used by this servlet. This function provides a common setup method for use
+     * by the test framework or the servlet's init() function.
+     */
+    void setUserStore(UserStore userStore) {
+        this.userStore = userStore;
+    }
+
     /**
      * This function fires when a user navigates to the admin page. It displays a message on the page, which differs
-     * depending on if you are logged in, and whether or not you are an admin.
+     * depending on if you are logged in, and whether or not you are an admin. It also has administrative buttons to
+     * delete group of entities.
      * The page contains information pertaining to administration if you are an admin.
      */
     @Override
@@ -39,6 +85,26 @@ public class AdminServlet extends HttpServlet {
         return;
     }
 
-}
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String user = (String) request.getSession().getAttribute("user");
 
+        if (AdminHelper.isAdmin(user)) {
+            if (request.getParameter("deleteUsersButton") != null) {
+                messageStore.deleteAllMessages();
+                userStore.deleteAllUsers();
+                response.sendRedirect("/logout");
+                return;
+            } else if (request.getParameter("deleteMessagesButton") != null) {
+                messageStore.deleteAllMessages();
+            } else if (request.getParameter("deleteConversationsButton") != null) {
+                messageStore.deleteAllMessages();
+                conversationStore.deleteAllConversations();
+            }
+        }
+
+        request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
+        return;
+    }
+}
 

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -64,7 +64,7 @@ public class ConversationStore {
     conversations = new ArrayList<>();
   }
 
-/** Access the current set of conversations known to the application. */
+  /** Access the current set of conversations known to the application. */
   public List<Conversation> getAllConversations() {
     return conversations;
   }
@@ -103,6 +103,11 @@ public class ConversationStore {
 
   public int getNumConversations() {
     return conversations.size();
+  }
+
+  public void deleteAllConversations() {
+    persistentStorageAgent.deleteAllConversations(conversations);
+    conversations.clear();
   }
 
 }

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -90,8 +90,17 @@ public class MessageStore {
     this.messages = messages;
   }
 
+  public List<Message> getMessages() {
+    return messages;
+  }
+
   public int getNumMessages() {
     return messages.size();
+  }
+
+  public void deleteAllMessages() {
+    persistentStorageAgent.deleteAllMessages(messages);
+    messages.clear();
   }
 
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -131,5 +131,9 @@ public class UserStore {
     return users.size();
   }
 
-}
+  public void deleteAllUsers() {
+    persistentStorageAgent.deleteAllUsers(users);
+    users.clear();
+  }
 
+}

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -18,11 +18,7 @@ import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
 import codeu.model.store.persistence.PersistentDataStoreException;
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.*;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -179,5 +175,26 @@ public class PersistentDataStore {
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
     datastore.put(conversationEntity);
   }
-}
 
+  public void deleteAllUsers(List<User> users) {
+    for (User user : users) {
+      Key userKey = KeyFactory.createKey("chat-users", user.getId().toString());
+      datastore.delete(userKey);
+    }
+  }
+
+  public void deleteAllMessages(List<Message> messages) {
+    for (Message message : messages) {
+      Key messageKey = KeyFactory.createKey("chat-messages", message.getId().toString());
+      datastore.delete(messageKey);
+    }
+  }
+
+  public void deleteAllConversations(List<Conversation> conversations) {
+    for (Conversation conversation : conversations) {
+      Key conversationKey = KeyFactory.createKey("chat-conversations", conversation.getId().toString());
+      datastore.delete(conversationKey);
+    }
+  }
+
+}

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -103,4 +103,17 @@ public class PersistentStorageAgent {
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
   }
+
+  public void deleteAllUsers(List<User> users) {
+    persistentDataStore.deleteAllUsers(users);
+  }
+
+  public void deleteAllMessages(List<Message> messages) {
+    persistentDataStore.deleteAllMessages(messages);
+  }
+
+  public void deleteAllConversations(List<Conversation> conversations) {
+    persistentDataStore.deleteAllConversations(conversations);
+  }
+
 }

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -7,7 +7,8 @@ import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.persistence.PersistentStorageAgent;
-import com.google.appengine.repackaged.org.apache.http.util.Asserts;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,8 +20,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.UUID;
 
 public class AdminServletTest {
 
@@ -29,10 +31,12 @@ public class AdminServletTest {
     private HttpSession mockSession;
     private HttpServletResponse mockResponse;
     private RequestDispatcher mockRequestDispatcher;
+    private ConversationStore fakeConversationStore;
+    private MessageStore fakeMessageStore;
+    private UserStore fakeUserStore;
     private PersistentStorageAgent mockPersistentStorageAgent;
-    private ConversationStore mockConversationStore;
-    private MessageStore mockMessageStore;
-    private UserStore mockUserStore;
+
+    private String adminUser = "Justin";
 
     @Before
     public void setup() {
@@ -49,26 +53,26 @@ public class AdminServletTest {
 
         mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
 
-        mockConversationStore = ConversationStore.getTestInstance(mockPersistentStorageAgent);
-        ArrayList<Conversation> testConversations = new ArrayList<>();
+        fakeConversationStore = ConversationStore.getTestInstance(mockPersistentStorageAgent);
         for (int i = 0; i < 123; i++) {
-            testConversations.add(null);
+            fakeConversationStore.addConversation(new Conversation(UUID.randomUUID(), UUID.randomUUID(),
+                    "Conversation " + i, Instant.now()));
         }
-        mockConversationStore.setConversations(testConversations);
-
-        mockMessageStore = MessageStore.getTestInstance(mockPersistentStorageAgent);
-        ArrayList<Message> testMessages = new ArrayList<>();
+        fakeMessageStore = MessageStore.getTestInstance(mockPersistentStorageAgent);
         for (int i = 0; i < 1234; i++) {
-            testMessages.add(null);
+            fakeMessageStore.addMessage(new Message(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                    "Message " + i, Instant.now()));
         }
-        mockMessageStore.setMessages(testMessages);
 
-        mockUserStore = UserStore.getTestInstance(mockPersistentStorageAgent);
-        ArrayList<User> testUsers = new ArrayList<>();
+        fakeUserStore = UserStore.getTestInstance(mockPersistentStorageAgent);
         for (int i = 0; i < 12345; i++) {
-            testUsers.add(null);
+            fakeUserStore.addUser(new User(UUID.randomUUID(), "User " + i, "password",
+                    Instant.now()));
         }
-        mockUserStore.setUsers(testUsers);
+
+        adminServlet.setConversationStore(fakeConversationStore);
+        adminServlet.setMessageStore(fakeMessageStore);
+        adminServlet.setUserStore(fakeUserStore);
 
     }
 
@@ -93,16 +97,68 @@ public class AdminServletTest {
 
     @Test
     public void testDoGet_UserIsAdmin() throws IOException, ServletException {
-        String admin = "Justin";
-        Mockito.when(mockSession.getAttribute("user")).thenReturn(admin);
+
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(adminUser);
 
         adminServlet.doGet(mockRequest, mockResponse);
 
-        Mockito.verify(mockSession).setAttribute("adminMessage", "Hello " + admin + "! Welcome to the admin page!");
+        Mockito.verify(mockSession).setAttribute("adminMessage", "Hello " + adminUser + "! Welcome to the admin page!");
 
-        Assert.assertEquals(123, mockConversationStore.getNumConversations());
-        Assert.assertEquals(1234, mockMessageStore.getNumMessages());
-        Assert.assertEquals(12345, mockUserStore.getNumUsers());
+        Assert.assertEquals(123, fakeConversationStore.getNumConversations());
+        Assert.assertEquals(1234, fakeMessageStore.getNumMessages());
+        Assert.assertEquals(12345, fakeUserStore.getNumUsers());
+
+        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testDoPost() throws IOException, ServletException {
+        adminServlet.doPost(mockRequest, mockResponse);
+        Assert.assertNull(mockRequest.getParameter("deleteUsersButton"));
+        Assert.assertNull(mockRequest.getParameter("deleteMessagesButton"));
+        Assert.assertNull(mockRequest.getParameter("deleteConversationsButton"));
+
+        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testDoPost_DeleteUsers() throws ServletException, IOException {
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(adminUser);
+
+        Assert.assertEquals(12345, fakeUserStore.getNumUsers());
+        Mockito.when(mockRequest.getParameter("deleteUsersButton")).thenReturn("notNull");
+
+        adminServlet.doPost(mockRequest, mockResponse);
+
+        Mockito.verify(mockResponse).sendRedirect("/logout");
+
+        Assert.assertEquals(0, fakeUserStore.getNumUsers());
+    }
+
+    @Test
+    public void testDoPost_DeleteMessages() throws ServletException, IOException {
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(adminUser);
+
+        Assert.assertEquals(1234, fakeMessageStore.getNumMessages());
+        Mockito.when(mockRequest.getParameter("deleteMessagesButton")).thenReturn("notNull");
+
+        adminServlet.doPost(mockRequest, mockResponse);
+
+        Assert.assertEquals(0, fakeMessageStore.getNumMessages());
+
+        Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testDoPost_DeleteConversations() throws ServletException, IOException {
+        Mockito.when(mockSession.getAttribute("user")).thenReturn(adminUser);
+
+        Assert.assertEquals(123, fakeConversationStore.getNumConversations());
+        Mockito.when(mockRequest.getParameter("deleteConversationsButton")).thenReturn("notNull");
+
+        adminServlet.doPost(mockRequest, mockResponse);
+
+        Assert.assertEquals(0, fakeConversationStore.getNumConversations());
 
         Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11599574/41571768-05a750e6-7332-11e8-9025-0a146b18aa13.png)
I just added a feature I thought would be good for the final product of the admin page; being able to delete all users, messages, and conversations as an admin.

The deletion buttons might seem like they don't work locally but it is because you have to wait at least 30 seconds for your local datastore to actually run and save changes before you stop the app. This isn't even just for deleting—if you run your app locally and register a user and then force stop your app right away, you'll find out that the user wont even be saved in the database for the next run because it needs to be written into the datastore first (which I believe updates every 30 seconds).

Important notes for delete feature:

1. If you delete all conversations then all messages are deleted as well (this is self explanatory)
2. If you delete all users then all messages are deleted as well because the way the app currently displays author names for messages is by getting the authorId of a message and then using that authorId to get a User from the UserStore and finally their username. So if we delete users and not messages and go into any conversation with a message in it, that will crash the app because the user cannot be found in UserStore and all of a sudden we're trying to call .getName() on a null object. Possible change: Just store the author name with the messages themselves so messages can be kept. I'll refactor this when I have time!

Note: This pull request is one of the two split out of the original pull request I had containing two features: https://github.com/sergio-castanon/CodeU-Spring-2018/pull/8